### PR TITLE
fixed some bugs in the `align` substep

### DIFF
--- a/.sidekick/setup/make_these_links.txt
+++ b/.sidekick/setup/make_these_links.txt
@@ -26,3 +26,6 @@
 
 # A job-specific data folder is required for the workflow
 ../../data/job/rnaseq_workflow   ./data/job
+
+# External genomic-references should be in ext/genomes
+../../data/ext/genomes   ./data/ext/genomes

--- a/scripts/snake_recipes/featureCounts.smk
+++ b/scripts/snake_recipes/featureCounts.smk
@@ -42,6 +42,7 @@ rule shorten_feature_counts:
         "{prefix}.fcount.short"
 
     shell:
+        # Note that `cut -f789-` takes all columns from 789 onwards
         """
-        cat {input} | cut -f1,6 > {output}
+        cat {input} | cut -f1,6- > {output}
         """

--- a/substeps/align/Snakefile
+++ b/substeps/align/Snakefile
@@ -1,5 +1,6 @@
 import pandas as pd
 import yaml
+from os.path import join
 
 from snakemake.utils import min_version
 from snakemake.utils import validate
@@ -17,15 +18,16 @@ validate(config, "conf_schemas/snake_config.schema.yaml")
 # ---- definition of the samples for study here
 
 def define_rnaseq_samples(filepath):
-    rnaseq_sample_table = pd.read_csv(
-        filepath, sep = "\t"
+    rnaseq_samples = pd.read_csv(
+        filepath, sep = "\t", comment="#"
     ).set_index(
         ["study_id", "sample_id", "run_id", "lane_id"], drop = False
     )
-    rnaseq_sample_table.index = rnaseq_samples_table.index.set_levels(
-        [i.astype(str) for i in rnaseq_samples_table.index.levels]
+    rnaseq_samples.index = rnaseq_samples.index.set_levels(
+        [i.astype(str) for i in rnaseq_samples.index.levels]
     )
-    return rnaseq_samples_table
+    return rnaseq_samples
+
 
 rnaseq_samples = define_rnaseq_samples(config["rnaseq_samples"])
 validate(rnaseq_samples, "conf_schemas/rnaseq_samples.schema.yaml")
@@ -60,11 +62,14 @@ subworkflow prefilter:
 
 # -- required files
 
-# prefilter("data/job/{study_id}/{sample_id}/{run_id}_{lane_id}_1.fastq.gz"),
+# This ensures that the feature-counts for each sequencing sample on each lane
+# are obtained:
+
 required_files = expand(
-    "data/job/" + \
-        "{unit.study_id}/unit.sample_id" + \
-        "{unit.run_id}_{unit.lane_id}.fcount.short",
+    join(
+        "data", "job", "{unit.study_id}", "{unit.sample_id}",
+        "{unit.run_id}_{unit.lane_id}.fcount.short"
+    ),
     unit=rnaseq_samples.itertuples()
 )
 

--- a/substeps/prefilter/Snakefile
+++ b/substeps/prefilter/Snakefile
@@ -1,5 +1,6 @@
 import pandas as pd
 import yaml
+from os.path import join
 
 from snakemake.utils import min_version
 from snakemake.utils import validate
@@ -14,15 +15,21 @@ validate(config, "conf_schemas/snake_config.schema.yaml")
 
 # ---- definition of samples for study here
 
-rnaseq_samples = pd.read_csv(
-        config["rnaseq_samples"], sep = "\t"
+def define_rnaseq_samples(filepath):
+    rnaseq_samples = pd.read_csv(
+        filepath, sep = "\t", comment="#"
     ).set_index(
-        ["study_id", "sample_id", "run_id", "lane_id"], drop=False
+        ["study_id", "sample_id", "run_id", "lane_id"], drop = False
     )
-rnaseq_samples.index = rnaseq_samples.index.set_levels(
+    rnaseq_samples.index = rnaseq_samples.index.set_levels(
         [i.astype(str) for i in rnaseq_samples.index.levels]
     )
+    return rnaseq_samples
+
+
+rnaseq_samples = define_rnaseq_samples(config["rnaseq_samples"])
 validate(rnaseq_samples, "conf_schemas/rnaseq_samples.schema.yaml")
+
 
 # ---- definition of command line params for the programs used here
 
@@ -33,17 +40,20 @@ validate(
     rnaseq_program_params, "conf_schemas/rnaseq_program_params.schema.yaml"
 )
 
+
 # -- targets of the current workflow-step
 
 required_files = expand(
-    "data/job/" + \
-        "{unit.study_id}/{unit.sample_id}/" + \
-        "{unit.run_id}_{unit.lane_id}_{read}.fastq.gz",
+    join(
+        "data", "job", "{unit.study_id}", "{unit.sample_id}",
+        "{unit.run_id}_{unit.lane_id}_{read}.fastq.gz"
+    ),
     unit=rnaseq_samples.itertuples(),
     read=[1, 2]
 )
 
 print(required_files)
+
 
 # -- rules
 
@@ -58,6 +68,7 @@ rule faker:
         """
         touch doc/fake_report.pdf
         """
+
 
 # -- imported rules
 


### PR DESCRIPTION
Fixed bugs:
- shorten_feature_counts was supposed to return columns 1 and
  6-onwards from the original feature_counts files (but returned
  cols 1 to 6)

- a link to from data/ext/genomes to the calling project's
  `data/ext/genomes` should be present

New features
- #-prefixed comment lines can be dropped from the
  `rnaseq_samples.tsv` file

- added a function to import and set the index on the
  `rnaseq_samples` data table

Refactoring
- neatened up the file-path combiner used when constructing
  required_files