### PR TITLE
add `hisat2` alignment reports to `multiqc`

### DIFF
--- a/scripts/snake_recipes/align_hisat2.smk
+++ b/scripts/snake_recipes/align_hisat2.smk
@@ -18,12 +18,18 @@ rule hisat2:
         )
 
     log:
-        "logs/hisat2/{sequencing_sample_id}.bam"
+        # log and qc summary are the same; therefore output to the alignment
+        # data directory rather than the log directory
+        os.path.join(
+            align_dirs["initial"], "{sequencing_sample_id}.log"
+        )
 
     params:
         # `idx` is required, `extra` is optional
         idx = reference_params["hisat2_index"],
-        extra = program_params["hisat2"]
+        extra = "--new-summary {}".format(
+            program_params["hisat2"]
+        )
 
     threads: 4
 

--- a/substeps/filter_and_align/Snakefile
+++ b/substeps/filter_and_align/Snakefile
@@ -109,7 +109,7 @@ feature_counts_files = expand(
 
 qc_reports = get_filter_and_align_reports(
     sequencing_samples=sequencing_samples, read_dirs=read_dirs,
-    fastqc_dirs=fastqc_dirs
+    fastqc_dirs=fastqc_dirs, align_dirs=align_dirs
 )
 
 # A QC report that combines all single-sample QC reports


### PR DESCRIPTION
- put `hisat2` logfiles into alignment data dir

- added function to compute the location of hisat2 reports for all
  aligned samples

- ensure `Snakefile` for `filter_and_align` includes the `hisat2`
  reports in the `multiqc` summary