### PR TITLE
rule to get annotation data from ensembl datasets

### DIFF
--- a/TODO.rnaseq_workflow.md
+++ b/TODO.rnaseq_workflow.md
@@ -1,0 +1,11 @@
+Add requirements to cover:
+
+- requirements for `get_ensembl_gene_details.smk.R`
+    - library(biomaRt)
+    - library(magrittr)
+    - library(readr)
+    - library(rtracklayer)
+    - library(reeq)
+
+- requirements for running the workflow
+    - snakemake etc

--- a/conf_schemas/filter_and_align/reference_params.schema.yaml
+++ b/conf_schemas/filter_and_align/reference_params.schema.yaml
@@ -32,3 +32,5 @@ properties:
 required:
   - hisat2_index
   - annotation
+  - annotation_version
+  - biomart_dataset

--- a/scripts/snake_recipes/get_ensembl_gene_details.smk.R
+++ b/scripts/snake_recipes/get_ensembl_gene_details.smk.R
@@ -1,0 +1,67 @@
+# This script should only be called by snakemake
+
+library(biomaRt)
+library(magrittr)
+library(readr)
+library(rtracklayer)
+library(reeq)
+
+# ----
+
+parse_gtf <- function(gtf_path){
+  gtf <- rtracklayer::import(gtf_path)
+}
+
+get_genes_from_gtf <- function(gtf){
+  gtf[which(gtf$type == "gene"), ]
+}
+
+get_database <- function(smk){
+  biomaRt::useEnsembl(
+    "ensembl",
+    version = smk@params[["ensembl_version"]],
+    dataset = smk@params[["ensembl_dataset"]]
+  )
+}
+
+get_gene_df_from_gtf <- function(smk, reqd_columns){
+  gene_df <- smk@input[["gtf"]] %>%
+    parse_gtf() %>%
+    get_genes_from_gtf() %>%
+    as.data.frame()
+
+  gene_df[, reqd_columns]
+}
+
+main <- function(smk){
+  # extract a subset of the metadata for gene builds from the transcriptome
+  # definition
+  gtf_columns <- paste(
+    "gene", c("id", "version", "name", "source", "biotype"), sep = "_"
+  )
+  gene_df <- get_gene_df_from_gtf(smk, gtf_columns)
+
+  # extract gc content from a biomaRt database
+  mart <- get_database(smk)
+  gc_percent <- reeq::get_gc_percent(
+    gene_df$gene_id, mart
+  )
+
+  # join the gc content to the gene-build metadata and write it to a file
+  results <- merge(
+    gc_percent,
+    gene_df,
+    by.x = "feature_id",
+    by.y = "gene_id"
+  )
+
+  readr::write_tsv(
+    results,
+    path = smk@output[["tsv"]]
+  )
+}
+
+# ----
+
+main(snakemake)
+

--- a/substeps/filter_and_align/Snakefile
+++ b/substeps/filter_and_align/Snakefile
@@ -103,6 +103,10 @@ feature_counts_files = expand(
     unit=sequencing_samples.itertuples()
 )
 
+annotation_files = [
+    os.path.join(job_dir, "annotations", "ensembl_gene_details.tsv")
+]
+
 # Make a cutadapt report for each (sample, run, lane)
 # Make a fastqc report for both raw and trimmed fastq files from each
 #   (sample, run, lane, read direction)
@@ -125,6 +129,7 @@ multiqc_report = os.path.join(
 
 required_files = \
     feature_counts_files + \
+    annotation_files + \
     qc_reports + \
     [multiqc_report]
 
@@ -152,3 +157,27 @@ include: "scripts/snake_recipes/align_hisat2.smk"
 include: "scripts/snake_recipes/quantify_subread.smk"
 include: "scripts/snake_recipes/quality_fastqc.smk"
 include: "scripts/snake_recipes/quality_multiqc.smk"
+
+# -- local rules
+
+rule ensembl_gene_details:
+    message:
+        """
+        --- Extract gene-information from ensembl database and ensembl gtf: GC
+            content, gene-type etc
+        """
+
+    input:
+        gtf = reference_params["annotation"]
+
+    output:
+        tsv = os.path.join(
+            job_dir, "annotations", "ensembl_gene_details.tsv"
+        )
+
+    params:
+        ensembl_version = reference_params["annotation_version"],
+        ensembl_dataset = reference_params["biomart_dataset"]
+
+    script:
+        "scripts/snake_recipes/get_ensembl_gene_details.smk.R"

--- a/substeps/filter_and_align/scripts/snake_recipes/get_ensembl_gene_details.smk.R
+++ b/substeps/filter_and_align/scripts/snake_recipes/get_ensembl_gene_details.smk.R
@@ -1,0 +1,1 @@
+../../../../scripts/snake_recipes/get_ensembl_gene_details.smk.R


### PR DESCRIPTION
Snakemake script added (from nil_cpi project) to obtain the
gene-annotations / GC content etc.

This script is ran within filter_and_align since there are
alignment qc steps planned that depend on this information.

Annotation_version and biomart database should be explicit in
the reference config.

todo note re "Dependencies for scripts in the workflow should be
stated somewhere"